### PR TITLE
Add Squid RPS game

### DIFF
--- a/cogs/game.py
+++ b/cogs/game.py
@@ -1362,8 +1362,8 @@ class SquidRPSView(discord.ui.View):
             description="選擇要留下哪一手",
             color=common.bot_color,
         )
-        embed.add_field(name="你的雙手", value=f"{combo[0]}、{combo[1]}")
-        embed.add_field(name="Natalie的雙手", value=f"{self.bot_combo[0]}、{self.bot_combo[1]}")
+        embed.add_field(name="Natalie的雙手", value=f"{self.bot_combo[0]}、{self.bot_combo[1]}", inline=False)
+        embed.add_field(name="你的雙手", value=f"{combo[0]}、{combo[1]}", inline=False)
         embed.add_field(name="手槍彈夾", value=self.clip_display(), inline=False)
         await interaction.response.edit_message(embed=embed, view=self)
 

--- a/cogs/game.py
+++ b/cogs/game.py
@@ -1207,23 +1207,23 @@ class SquidRPS(commands.Cog):
     def __init__(self, client: commands.Bot):
         self.bot = client
         self.combo_choices = [
-            ("石頭", "剪刀"),
-            ("石頭", "布"),
-            ("剪刀", "石頭"),
-            ("剪刀", "布"),
-            ("布", "石頭"),
-            ("布", "剪刀"),
+            ("✊", "✌️"),
+            ("✊", "✋"),
+            ("✌️", "✊"),
+            ("✌️", "✋"),
+            ("✋", "✊"),
+            ("✋", "✌️"),
         ]
         self.bot_choices = [
-            ("石頭", "布"),
-            ("石頭", "剪刀"),
-            ("剪刀", "布"),
+            ("✊", "✋"),
+            ("✊", "✌️"),
+            ("✌️", "✋"),
         ]
 
     def rps_result(self, a: str, b: str) -> int:
         if a == b:
             return 0
-        win_table = {("石頭", "剪刀"), ("剪刀", "布"), ("布", "石頭")}
+        win_table = {("✊", "✌️"), ("✌️", "✋"), ("✋", "✊")}
         if (a, b) in win_table:
             return 1
         return -1
@@ -1355,37 +1355,37 @@ class SquidRPSView(discord.ui.View):
         embed.add_field(name="Natalie的雙手", value=f"{self.bot_combo[0]}、{self.bot_combo[1]}")
         await interaction.response.edit_message(embed=embed, view=self)
 
-    @discord.ui.button(label="石頭&剪刀", style=discord.ButtonStyle.gray)
+    @discord.ui.button(label="✊&✌️", style=discord.ButtonStyle.gray)
     async def combo1(self, interaction, button):
-        await self.choose_combo(interaction, ("石頭", "剪刀"))
+        await self.choose_combo(interaction, ("✊", "✌️"))
 
-    @discord.ui.button(label="石頭&布", style=discord.ButtonStyle.gray)
+    @discord.ui.button(label="✊&✋", style=discord.ButtonStyle.gray)
     async def combo2(self, interaction, button):
-        await self.choose_combo(interaction, ("石頭", "布"))
+        await self.choose_combo(interaction, ("✊", "✋"))
 
-    @discord.ui.button(label="剪刀&石頭", style=discord.ButtonStyle.gray)
+    @discord.ui.button(label="✌️&✊", style=discord.ButtonStyle.gray)
     async def combo3(self, interaction, button):
-        await self.choose_combo(interaction, ("剪刀", "石頭"))
+        await self.choose_combo(interaction, ("✌️", "✊"))
 
-    @discord.ui.button(label="剪刀&布", style=discord.ButtonStyle.gray)
+    @discord.ui.button(label="✌️&✋", style=discord.ButtonStyle.gray)
     async def combo4(self, interaction, button):
-        await self.choose_combo(interaction, ("剪刀", "布"))
+        await self.choose_combo(interaction, ("✌️", "✋"))
 
-    @discord.ui.button(label="布&石頭", style=discord.ButtonStyle.gray)
+    @discord.ui.button(label="✋&✊", style=discord.ButtonStyle.gray)
     async def combo5(self, interaction, button):
-        await self.choose_combo(interaction, ("布", "石頭"))
+        await self.choose_combo(interaction, ("✋", "✊"))
 
-    @discord.ui.button(label="布&剪刀", style=discord.ButtonStyle.gray)
+    @discord.ui.button(label="✋&✌️", style=discord.ButtonStyle.gray)
     async def combo6(self, interaction, button):
-        await self.choose_combo(interaction, ("布", "剪刀"))
+        await self.choose_combo(interaction, ("✋", "✌️"))
 
     @discord.ui.button(label="收左手", style=discord.ButtonStyle.blurple, disabled=True)
     async def left_button(self, interaction, button):
-        await self.keep_hand(interaction, 0)
+        await self.keep_hand(interaction, 1)
 
     @discord.ui.button(label="收右手", style=discord.ButtonStyle.blurple, disabled=True)
     async def right_button(self, interaction, button):
-        await self.keep_hand(interaction, 1)
+        await self.keep_hand(interaction, 0)
 
     @property
     def combo_buttons(self):
@@ -1402,7 +1402,7 @@ class SquidRPSView(discord.ui.View):
             desc += "，平手!"
             embed = Embed(title="魷魚猜拳", description=desc, color=common.bot_color)
             await interaction.response.edit_message(embed=embed, view=self)
-            await asyncio.sleep(3)
+            await asyncio.sleep(5)
             await self.reset_round()
             return
 
@@ -1426,7 +1426,7 @@ class SquidRPSView(discord.ui.View):
                     embed = Embed(title="魷魚猜拳", description=desc, color=common.bot_color)
                     common.datawrite(data)
                     await interaction.response.edit_message(embed=embed, view=self)
-                    await asyncio.sleep(3)
+                    await asyncio.sleep(5)
                     await self.reset_round()
                     return
             else:
@@ -1444,7 +1444,7 @@ class SquidRPSView(discord.ui.View):
                     embed = Embed(title="魷魚猜拳", description=desc, color=common.bot_color)
                     common.datawrite(data)
                     await interaction.response.edit_message(embed=embed, view=self)
-                    await asyncio.sleep(3)
+                    await asyncio.sleep(5)
                     await self.reset_round()
                     return
 

--- a/cogs/general.py
+++ b/cogs/general.py
@@ -70,7 +70,7 @@ class General(commands.Cog):
             message.add_field(name="個人資料",value=f"等級:**{userlevel.level}**  經驗值:**{userlevel.level_exp}**/**{userlevel.level_next_exp}**\n你有**{cake}**塊{self.bot.get_emoji(common.cake_emoji_id)}",inline=False)
             cake_emoji = self.bot.get_emoji(common.cake_emoji_id)
             
-            general_commands_list=f'/info 查看指令表及個人資料\n/eat 餵食Natalie一些{cake_emoji} (1 cake = 1 exp)\n/cake_give 給予他人{cake_emoji}\n/mining_info 挖礦小遊戲資訊\n/blackjack 21點遊戲\n/check_sevencolor_restday 確認七色有沒有休假'
+            general_commands_list=f'/info 查看指令表及個人資料\n/eat 餵食Natalie一些{cake_emoji} (1 cake = 1 exp)\n/cake_give 給予他人{cake_emoji}\n/mining_info 挖礦小遊戲資訊\n/blackjack 21點遊戲\n/poker 撲克牌比大小\n/check_sevencolor_restday 確認七色有沒有休假'
             #如果等級>=5 且沒有在 抽獎仔/VIP 身分內，則顯示指令
             if userlevel.level >= 5 and all(role.id not in [621764669929160715, 605730134531637249] for role in interaction.user.roles):
                 general_commands_list += "\n/giveaway_join 加入抽獎頻道"


### PR DESCRIPTION
## Summary
- add `SquidRPS` cog implementing squid-game style rock-paper-scissors
- add interactive `SquidRPSView` for multi-round play
- register the new cog in `setup`

## Testing
- `python -m py_compile cogs/game.py`


------
https://chatgpt.com/codex/tasks/task_e_684e8c0f933883299fd218c8afb96d6d