### PR TITLE
Add squid RPS leaderboard

### DIFF
--- a/cogs/game.py
+++ b/cogs/game.py
@@ -1231,6 +1231,8 @@ class SquidRPS(commands.Cog):
         return f"你的勝率:{win_rate:.1%} 總場數:{data[userid]['squid_rps_round']}"
 
     def rps_result(self, a: str, b: str) -> int:
+        if a == b:
+            return 0
         win_table = {("✊", "✌️"), ("✌️", "✋"), ("✋", "✊")}
         if (a, b) in win_table:
             return 1
@@ -1457,6 +1459,16 @@ class SquidRPSView(discord.ui.View):
         bot_choice = self.bot_combo[self.bot_keep]
         result = self.compare(player_choice, bot_choice)
         desc = f"你出{player_choice}，Natalie出{bot_choice}"
+
+        if result == 0:
+            desc += "，平手!"
+            embed = Embed(title="魷魚猜拳", description=desc, color=common.bot_color)
+            embed.add_field(name="手槍彈夾", value=self.clip_display(), inline=False)
+            embed.set_footer(text=SquidRPS(self.bot).win_rate_show(str(self.command_interaction.user.id)))
+            await interaction.response.edit_message(embed=embed, view=self)
+            await asyncio.sleep(5)
+            await self.reset_round()
+            return
 
         # 扣下扳機
         self.shots_fired += 1

--- a/cogs/game.py
+++ b/cogs/game.py
@@ -1231,8 +1231,6 @@ class SquidRPS(commands.Cog):
         return f"你的勝率:{win_rate:.1%} 總場數:{data[userid]['squid_rps_round']}"
 
     def rps_result(self, a: str, b: str) -> int:
-        if a == b:
-            return 0
         win_table = {("✊", "✌️"), ("✌️", "✋"), ("✋", "✊")}
         if (a, b) in win_table:
             return 1
@@ -1459,14 +1457,6 @@ class SquidRPSView(discord.ui.View):
         bot_choice = self.bot_combo[self.bot_keep]
         result = self.compare(player_choice, bot_choice)
         desc = f"你出{player_choice}，Natalie出{bot_choice}"
-        if result == 0:
-            desc += "，平手!"
-            embed = Embed(title="魷魚猜拳", description=desc, color=common.bot_color)
-            embed.add_field(name="手槍彈夾", value=self.clip_display(), inline=False)
-            await interaction.response.edit_message(embed=embed, view=self)
-            await asyncio.sleep(5)
-            await self.reset_round()
-            return
 
         # 扣下扳機
         self.shots_fired += 1
@@ -1489,8 +1479,8 @@ class SquidRPSView(discord.ui.View):
                         value=f"你獲得了**{self.bet}**塊{self.cake_emoji}\n你現在擁有**{data[userid]['cake']}**塊{self.cake_emoji}",
                         inline=False,
                     )
-                    embed.set_footer(text=SquidRPS(self.bot).win_rate_show(userid))
                     common.datawrite(data)
+                    embed.set_footer(text=SquidRPS(self.bot).win_rate_show(userid))
                     await interaction.response.edit_message(embed=embed, view=None)
                     self.stop()
                     return
@@ -1498,8 +1488,8 @@ class SquidRPSView(discord.ui.View):
                     desc += "\n是空包彈... 下一回合!"
                     embed = Embed(title="魷魚猜拳", description=desc, color=common.bot_color)
                     embed.add_field(name="手槍彈夾", value=self.clip_display(), inline=False)
-                    embed.set_footer(text=SquidRPS(self.bot).win_rate_show(userid))
                     common.datawrite(data)
+                    embed.set_footer(text=SquidRPS(self.bot).win_rate_show(userid))
                     await interaction.response.edit_message(embed=embed, view=self)
                     await asyncio.sleep(5)
                     await self.reset_round()
@@ -1517,8 +1507,8 @@ class SquidRPSView(discord.ui.View):
                         value=f"你失去了**{self.bet}**塊{self.cake_emoji}\n你現在擁有**{data[userid]['cake']}**塊{self.cake_emoji}",
                         inline=False,
                     )
-                    embed.set_footer(text=SquidRPS(self.bot).win_rate_show(userid))
                     common.datawrite(data)
+                    embed.set_footer(text=SquidRPS(self.bot).win_rate_show(userid))
                     await interaction.response.edit_message(embed=embed, view=None)
                     self.stop()
                     return
@@ -1526,8 +1516,8 @@ class SquidRPSView(discord.ui.View):
                     desc += "\n是空包彈... 下一回合!"
                     embed = Embed(title="魷魚猜拳", description=desc, color=common.bot_color)
                     embed.add_field(name="手槍彈夾", value=self.clip_display(), inline=False)
-                    embed.set_footer(text=SquidRPS(self.bot).win_rate_show(userid))
                     common.datawrite(data)
+                    embed.set_footer(text=SquidRPS(self.bot).win_rate_show(userid))
                     await interaction.response.edit_message(embed=embed, view=self)
                     await asyncio.sleep(5)
                     await self.reset_round()

--- a/cogs/general.py
+++ b/cogs/general.py
@@ -78,7 +78,7 @@ class General(commands.Cog):
             message.add_field(name="指令表",value=general_commands_list,inline=False)
             message.add_field(
                 name="排行榜",
-                value=f'/level_leaderboard 等級排行榜\n/voice_leaderboard 語音活躍排行榜\n/blackjack_leaderboard 21點勝率排行榜\n/cake_leaderboard 蛋糕排行榜',
+                value=f'/level_leaderboard 等級排行榜\n/voice_leaderboard 語音活躍排行榜\n/blackjack_leaderboard 21點勝率排行榜\n/squid_rps_leaderboard 魷魚猜拳勝率排行榜\n/cake_leaderboard 蛋糕排行榜',
                 inline=False)
             await interaction.response.send_message(embed=message)
 


### PR DESCRIPTION
## Summary
- add win rate tracking for squid RPS
- show stats in squid RPS embeds
- implement `/squid_rps_leaderboard`
- mention leaderboard command in info

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68502b5285fc8329a6d5fbb11a2df5eb