### PR TITLE
Add difficulty options to squid RPS

### DIFF
--- a/cogs/game.py
+++ b/cogs/game.py
@@ -1794,9 +1794,14 @@ class SquidRPSView(discord.ui.View):
                         if self.difficulty == "hard":
                             embed.add_field(name="Natalie血量", value=self.hp_display(), inline=False)
                         embed.add_field(name="手槍彈夾", value=self.clip_display(), inline=False)
+                        if self.difficulty == "normal":
+                            result_message = f"你獲得了**{gain}**塊{self.cake_emoji}\n"
+                        elif self.difficulty == "hard":
+                            result_message = f"你獲得了**{gain}**塊{self.cake_emoji} (hard * 3)\n"
+                        result_message += f"你現在擁有**{data[userid]['cake']}**塊{self.cake_emoji}"
                         embed.add_field(
                             name="結果",
-                            value=f"你獲得了**{gain}**塊{self.cake_emoji}\n你現在擁有**{data[userid]['cake']}**塊{self.cake_emoji}",
+                            value=result_message,
                             inline=False,
                         )
                         common.datawrite(data)

--- a/cogs/game.py
+++ b/cogs/game.py
@@ -611,7 +611,7 @@ class BlackJack(commands.Cog):
             data[userid]["blackjack_playing"] = True
             common.datawrite(data)
         #選項給予
-        message.set_footer(text=self.win_rate_show(userid, difficulty))
+        message.set_footer(text=self.win_rate_show(userid))
         await interaction.followup.send(embed=message,view = BlackJackButton(user=interaction,bet=bet,player_cards=player_cards,bot_cards=bot_cards,playing_deck=playing_deck,client=self.bot,display_bot_points=display_bot_points,display_bot_cards=display_bot_cards))
 
 


### PR DESCRIPTION
## Summary
- support choosing difficulty for Squid Game RPS
- show difficulty and Natalie HP in the game embed
- handle hard mode with two bullets and extra rewards

## Testing
- `python -m py_compile main.py cogs/*.py`

------
https://chatgpt.com/codex/tasks/task_e_685c18d5564483299f67eecc8f9b572b